### PR TITLE
tools: single-command install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,35 @@ Features
       via telnet. In order to disable it fix the original crash cause and remove
       `/var/luna/preferences/webosbrew_failsafe` flag file.
 
+Installation
+------------
+
+## Automated
+Execute the following snippet on target TV using SSH or Telnet:
+```sh
+curl -L https://raw.githubusercontent.com/webosbrew/webos-homebrew-channel/main/tools/install.sh | sh -
+
+# Update startup script
+cp /media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/startup.sh /media/cryptofs/apps/usr/palm/services/com.palmdts.devmode.service/start-devmode.sh
+```
+
+## Manual
+* Download [latest release
+  `.ipk`](https://github.com/webosbrew/webos-homebrew-channel/releases/)
+* Install it using `ares-install` SDK command or using the following command
+  directly on a TV:
+  ```sh
+  luna-send-pub -i 'luna://com.webos.appInstallService/dev/install' '{"id":"com.ares.defaultName","ipkUrl":"/tmp/path/to/hbchannel.ipk","subscribe":true}'`
+  ```
+* (root) Elevate privileges by running:
+  ```sh
+  /media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service
+  ```
+* (root) Update startup script:
+  ```sh
+  cp /media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/startup.sh /media/cryptofs/apps/usr/palm/services/com.palmdts.devmode.service/start-devmode.sh
+  ```
+
 Development
 -----------
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -e
+
+(
+MANIFEST_URL="${MANIFEST_URL:-https://github.com/webosbrew/webos-homebrew-channel/releases/latest/download/org.webosbrew.hbchannel.manifest.json}"
+export MANIFEST_URL
+
+echo "[ ] Downloading manifest..."
+export MANIFEST_JSON="$(curl -L $MANIFEST_URL)"
+
+export $(node -e '
+var manifest = JSON.parse(process.env.MANIFEST_JSON);
+console.info("IPK_URL=" + require("url").resolve(process.env.MANIFEST_URL, manifest.ipkUrl));
+console.info("IPK_SHA256=" + manifest.ipkHash.sha256);
+')
+
+echo "[ ] Downloading $IPK_URL..."
+curl -L $IPK_URL -o /tmp/hbchannel.ipk
+echo "$IPK_SHA256  /tmp/hbchannel.ipk" | sha256sum -c
+
+rm -rf /tmp/luna-install
+mkfifo /tmp/luna-install
+echo "[ ] Installing..."
+luna-send-pub -i 'luna://com.webos.appInstallService/dev/install' '{"id":"com.ares.defaultName","ipkUrl":"/tmp/hbchannel.ipk","subscribe":true}' >/tmp/luna-install &
+LUNA_PID=$!
+result="$(timeout -t 15 egrep -i -m 1 'installed|failed' /tmp/luna-install || echo timeout)"
+kill -term $LUNA_PID
+rm /tmp/luna-install
+
+case $result in
+    *installed*) ;;
+    *)
+        echo "[!] Install failed - $result"
+        exit 1
+    ;;
+esac
+
+/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service || echo "[!] Elevation failed - is Your TV rooted?"
+
+echo
+echo "[*]"
+echo "[*] Homebrew Channel Installed!"
+echo "[*]"
+echo
+)


### PR DESCRIPTION
We could also extend the guide to getting devmode SSH access without installing the SDK.

Theoretically, the install script should work fine without root.