### PR TITLE
services/service.json: explicitly declare all supported commands

### DIFF
--- a/services/services.json
+++ b/services/services.json
@@ -3,7 +3,52 @@
     "description": "Homebrew Channel Service",
     "services": [
         {
-            "name": "org.webosbrew.hbchannel.service"
+            "name": "org.webosbrew.hbchannel.service",
+            "description": "Homebrew Channel Service",
+            "commands": [
+                {
+                    "name": "checkRoot",
+                    "description": "Returns true if Homebrew Channel is capable of root execution",
+                    "public": true
+                },
+                {
+                    "name": "exec",
+                    "description": "Execute code as Homebrew Channel user (likely root)",
+                    "public": true
+                },
+                {
+                    "name": "spawn",
+                    "description": "Spawn a long-running command",
+                    "public": false
+                },
+
+                {
+                    "name": "install",
+                    "description": "Install application package",
+                    "public": true
+                },
+                {
+                    "name": "getAppInfo",
+                    "description": "Root-less luna://com.webos.applicationManager/getAppInfo equivalent",
+                    "public": true
+                },
+
+                {
+                    "name": "getConfiguration",
+                    "description": "Get current Homebrew Channel configuration",
+                    "public": true
+                },
+                {
+                    "name": "setConfiguration",
+                    "description": "Change Homebrew Channel configuration",
+                    "public": false
+                },
+                {
+                    "name": "reboot",
+                    "description": "Perform system reboot",
+                    "public": true
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
This should properly expose certain parts of our API as public on webOS
4.x+ (earlier versions make all service commands public regardless of
these flags)

Post-testing update: this *does not* work, at least on 4.9 (where permissions to our service are already limited), even though this file seems to match https://webostv.developer.lge.com/develop/js-services/creating-js-services/servicesjson/ properly. I guess we'll need to add `/var/luna-service2-dev/api-permissions.d` to some of our post-install scripts (likely `elevate-service`)