### PR TITLE
Excluding core-js from transpilation

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -11,7 +11,7 @@
                     "node": "0.10"
                 },
                 "useBuiltIns": "entry",
-                "corejs": "3.0"
+                "corejs": "3"
             }
         ],
         "@babel/preset-typescript"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = (env) => [
       rules: [
         {
           test: /\.m?js$/,
+          exclude: /core-js/,
           use: 'babel-loader',
         },
         {


### PR DESCRIPTION
The problem is that `node-fetch` is an `.mjs` package, and when they require `core-js` we transpile it, causing the exception (core-js shouldn't be transpiled)

https://github.com/zloirock/core-js/issues/514#issuecomment-476448971