### PR TITLE
Adding not yet completed role-file evaluation

### DIFF
--- a/services/elevate-service.legacy
+++ b/services/elevate-service.legacy
@@ -16,6 +16,23 @@ fi
 # arg2 if changed.
 safesed() {
     target=/tmp/_safesed.$$
+    if [[ "$1" == "role1" ]]; then
+        sed 's;, "";, "*", "";g' $2 > $target
+        if ! diff $2 $target ; then
+            cp $target $2
+            echo "[+] File changed"
+            RESCAN_NEEDED=1
+        fi
+    fi
+    if [[ "$1" == "role2" ]]; then
+        sed 's;"permissions": \[;"permissions": [{"service":"*","outbound":["*"],"inbound":["*"]},;g' $2 > $target
+        if ! diff $2 $target ; then
+            cp $target $2
+            echo "[+] File changed"
+            RESCAN_NEEDED=1
+        fi
+    fi
+
     if [[ ! -f $2 ]]; then
         echo "[!] $2 does not exist..."
     else
@@ -46,6 +63,10 @@ else
 
     echo "[ ] Exposing public API for '$SERVICE_NAME'..."
     safesed "s;$SERVICE_NAME.group;public;g" /var/luna-service2-dev/api-permissions.d/$SERVICE_NAME.api.json
+
+    echo "[ ] Extending role file permissions for '$SERVICE_NAME'..."
+    safesed role1 /var/luna-service2-dev/roles.d/$SERVICE_NAME.service.json
+    safesed role2 /var/luna-service2-dev/roles.d/$SERVICE_NAME.service.json
 fi
 
 if [ $RESCAN_NEEDED -eq 1 ]; then

--- a/services/elevate-service.ts
+++ b/services/elevate-service.ts
@@ -13,9 +13,20 @@ function isFile(path: string): boolean {
   }
 }
 
-function patchServiceFile(serviceFile: string): boolean {
+function patchServiceFile(serviceFile: string, appName?: string, serviceName?: string): boolean {
   const serviceFileOriginal = readFileSync(serviceFile).toString();
-  const serviceFileNew = serviceFileOriginal.replace('/usr/bin', '/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service');
+  let serviceFileNew;
+  if (!serviceFileOriginal.includes('jailer')){
+    console.info("[ ] Updating a NodeJS-Service.");
+    serviceFileNew = serviceFileOriginal.replace('/usr/bin', '/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service');
+  }else{
+    console.info("[ ] Updating a Native-Service.");
+    if ( appName && serviceName){
+      serviceFileNew = serviceFileOriginal.replace('/usr/bin/jailer -t native_devmode -i ' + appName + ' -p /media/developer/apps/usr/palm/services/' + serviceName + ' ', '');
+    }else{
+      console.info("[!] Updating Native-Service failed! Didn't got Application or Service name.");
+    }
+  }
 
   if (serviceFileNew !== serviceFileOriginal) {
     console.info(`[ ] Updating service definition: ${serviceFile}`);
@@ -45,7 +56,7 @@ function main(argv: string[]) {
 
   if (isFile(serviceFile)) {
     console.info(`[~] Found webOS 3.x+ service file: ${serviceFile}`);
-    if (patchServiceFile(serviceFile)) {
+    if (patchServiceFile(serviceFile, appName, serviceName)) {
       configChanged = true;
     }
 


### PR DESCRIPTION
Hey there, 

I've tried myself on adding service evaluation for the role files. It already adds and checks the wildcard for the allowedNames property. 
It actually only sets the wildcard for permission, but doesn't detect if it's already set. 
I think I have a error in the searching of the JSON array, but I can't get it to work. 
Maybe it's a snap for your fingers to get it working. Would be nice if you could have a look.

Maybe you can also get the legacy variant a bit prettier. Since there a spaces in sed, bash is interpreting it as new parameters, so I had to do a little work around, since I can't get it to work the other way.

Thanks! 