### PR TITLE
Autostart Fallback for webOS 4+

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -9,5 +9,9 @@
     "main": "index.html",
     "iconColor": "#cf0652",
     "type": "web",
-    "appDescription": "webOS Homebrew installer"
+    "appDescription": "webOS Homebrew installer",
+    "previewMetadata": {
+        "targetEndpoint": "luna://org.webosbrew.hbchannel.service/discovery",
+        "sourceEndpoint": "@PREVIEW.ENDPOINT.SOURCE_LOCAL_STOREAPP"
+    }
 }

--- a/appinfo.json
+++ b/appinfo.json
@@ -11,7 +11,7 @@
     "type": "web",
     "appDescription": "webOS Homebrew installer",
     "previewMetadata": {
-        "targetEndpoint": "luna://org.webosbrew.hbchannel.service/discovery",
+        "targetEndpoint": "luna://org.webosbrew.hbchannel.service/autostart",
         "sourceEndpoint": "@PREVIEW.ENDPOINT.SOURCE_LOCAL_STOREAPP"
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Manual installation:",
     "main": "frontend/index.js",
     "moduleDir": "frontend",
+    "os": ["!win32"],
     "scripts": {
         "build": "enyo pack",
         "build-service": "webpack",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "description": "Manual installation:",
     "main": "frontend/index.js",
     "moduleDir": "frontend",
-    "os": ["!win32"],
+    "os": [
+        "!win32"
+    ],
     "scripts": {
         "build": "enyo pack",
         "build-service": "webpack",

--- a/services/service.ts
+++ b/services/service.ts
@@ -524,6 +524,21 @@ function runService() {
       if (fs.existsSync('/tmp/webosbrew_startup')) {
         return { message: 'Startup script already executed.', returnValue: true };
       }
+      // Copy startup.sh if doesn't exist
+      if (!fs.existsSync('/var/lib/webosbrew/startup.sh')) {
+        try {
+          fs.mkdirSync('/var/lib/webosbrew/', { mode: 0o755 });
+        } catch (e) {
+          // Ignore
+        }
+        fs.copyFileSync(path.join(__dirname, 'startup.sh'), '/var/lib/webosbrew/startup.sh');
+      }
+      // Make startup.sh executable
+      try {
+        fs.accessSync('/var/lib/webosbrew/startup.sh', fs.constants.X_OK);
+      } catch (e) {
+        fs.chmodSync('/var/lib/webosbrew/startup.sh', 0o755);
+      }
       child_process.spawn('/bin/sh', ['-c', '/var/lib/webosbrew/startup.sh'], {
         cwd: '/home/root',
         env: { LD_PRELOAD: '' },

--- a/services/service.ts
+++ b/services/service.ts
@@ -514,6 +514,23 @@ function runService() {
       isTimeLimited: false,
     })),
   );
+
+  service.register(
+    'discovery',
+    tryRespond(async () => {
+      if (!runningAsRoot()) {
+        return { message: 'Not running as root.', returnValue: true };
+      }
+      if (fs.existsSync('/tmp/webosbrew_startup')) {
+        return { message: 'Startup script already executed.', returnValue: true };
+      }
+      child_process.spawn('/bin/sh', ['-c', '/var/lib/webosbrew/startup.sh'], {
+        detached: true,
+        stdio: ['ignore', 'ignore', 'ignore'],
+      });
+      return { returnValue: true };
+    }),
+  );
 }
 
 if (process.argv[2] === 'self-update') {

--- a/services/service.ts
+++ b/services/service.ts
@@ -516,7 +516,7 @@ function runService() {
   );
 
   service.register(
-    'discovery',
+    'autostart',
     tryRespond(async () => {
       if (!runningAsRoot()) {
         return { message: 'Not running as root.', returnValue: true };

--- a/services/service.ts
+++ b/services/service.ts
@@ -525,6 +525,8 @@ function runService() {
         return { message: 'Startup script already executed.', returnValue: true };
       }
       child_process.spawn('/bin/sh', ['-c', '/var/lib/webosbrew/startup.sh'], {
+        cwd: '/home/root',
+        env: { LD_PRELOAD: '' },
         detached: true,
         stdio: ['ignore', 'ignore', 'ignore'],
       });


### PR DESCRIPTION
After extra_conf.sh way got patched, this PR will provide a way to execute `startup.sh`. It works pretty reliable on webOS 4 and up, and should be future-proof as it's not a vulnerability, so it is not likely being patched.