### PR TITLE
fix Node.js v0.x/webOS 4 compatibility (untested)

### DIFF
--- a/services/service.ts
+++ b/services/service.ts
@@ -534,7 +534,7 @@ function runService() {
         } catch (e) {
           // Ignore
         }
-        fs.copyFileSync(path.join(__dirname, 'startup.sh'), '/var/lib/webosbrew/startup.sh');
+        await copyScript(path.join(__dirname, 'startup.sh'), '/var/lib/webosbrew/startup.sh');
       }
       // Make startup.sh executable
       try {

--- a/services/service.ts
+++ b/services/service.ts
@@ -537,11 +537,8 @@ function runService() {
         await copyScript(path.join(__dirname, 'startup.sh'), '/var/lib/webosbrew/startup.sh');
       }
       // Make startup.sh executable
-      try {
-        fs.accessSync('/var/lib/webosbrew/startup.sh', fs.constants.X_OK);
-      } catch (e) {
-        fs.chmodSync('/var/lib/webosbrew/startup.sh', 0o755);
-      }
+      fs.chmodSync('/var/lib/webosbrew/startup.sh', 0o755);
+  
       child_process.spawn('/bin/sh', ['-c', '/var/lib/webosbrew/startup.sh'], {
         cwd: '/home/root',
         env: { LD_PRELOAD: '' },

--- a/services/service.ts
+++ b/services/service.ts
@@ -520,7 +520,7 @@ function runService() {
 
   service.register(
     'autostart',
-    tryRespond(() => {
+    tryRespond(async () => {
       if (!runningAsRoot()) {
         return { message: 'Not running as root.', returnValue: true };
       }


### PR DESCRIPTION
`fs.copyFileSync()` was introduced in Node.js v8.5.0, but webOS 4 uses v0.12.2. Replace its use in autostart handler with `copyScript()`, which is already used everywhere else files are copied.

I haven't tested this at all.