### PR TITLE
startup: skip elevation if the script was called by the service itself

### DIFF
--- a/services/service.ts
+++ b/services/service.ts
@@ -490,19 +490,20 @@ function runService() {
         const bundledStartupChecksum = await hashFile(bundledStartup, 'sha256');
         const bundledJumpstartChecksum = await hashFile(bundledJumpstart, 'sha256');
 
-        const updateableChecksums = [
+        const updatableChecksums = [
           'c5e69325c5327cff3643b87fd9c4c905e06b600304eae820361dcb41ff52db92',
           'bcbe9f8cea451c40190334ee4819427b316c0dba889b502049fb99f7a4807c6b',
           '15bd94b71c652b5d64ff79f2a88f965f9a61992ed3ce064617323d6a950d5d49',
           '5caab3681cdd52cc9b59136a180cd0a1ffb98ec39bf571c38c0a4eb528ce13fb',
           'befe927c6f62b87545aaefb4b2648a227b22695fa0f78a228dcacf1fbba11aeb',
+          'd914b3b444433bf49ff83c3c0ae0b729cf7544c074e72c23ec24e5f86aaaf4ac',
         ];
 
         // RootMyTV v2
         if (await isFile(webosbrewStartup)) {
           const localChecksum = await hashFile(webosbrewStartup, 'sha256');
           if (localChecksum !== bundledStartupChecksum) {
-            if (updateableChecksums.indexOf(localChecksum) !== -1) {
+            if (updatableChecksums.indexOf(localChecksum) !== -1) {
               await copyScript(bundledStartup, webosbrewStartup);
               messages.push(`${webosbrewStartup} updated!`);
             } else {
@@ -526,7 +527,7 @@ function runService() {
         // RootMyTV v1
         if (await isFile(startDevmode)) {
           const localChecksum = await hashFile(startDevmode, 'sha256');
-          if (localChecksum !== bundledStartupChecksum && updateableChecksums.indexOf(localChecksum) !== -1) {
+          if (localChecksum !== bundledStartupChecksum && updatableChecksums.indexOf(localChecksum) !== -1) {
             await copyScript(bundledStartup, startDevmode);
             messages.push(`${startDevmode} updated!`);
           } else if (localChecksum !== bundledJumpstartChecksum && (await asyncReadFile(startDevmode)).indexOf('org.webosbrew') !== -1) {
@@ -655,7 +656,10 @@ function runService() {
 
       child_process.spawn('/bin/sh', ['-c', '/var/lib/webosbrew/startup.sh'], {
         cwd: '/home/root',
-        env: { LD_PRELOAD: '' },
+        env: {
+          LD_PRELOAD: '',
+          SKIP_ELEVATION: 'true',
+        },
         detached: true,
         stdio: ['ignore', 'ignore', 'ignore'],
       });

--- a/services/startup.sh
+++ b/services/startup.sh
@@ -116,11 +116,13 @@ else
     done
 
     # Deprecate old path
-    chattr -i /home/root/unwritable
-    rm -rf /home/root/unwritable
+    if [[ -d /home/root/unwritable ]]; then
+      chattr -i /home/root/unwritable
+      rm -rf /home/root/unwritable
+    fi
 
     # Automatically elevate Homebrew Channel service
-    if [[ -x /media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service ]]; then
+    if [[ -z "${SKIP_ELEVATION}" && -x /media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service ]]; then
         /media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service
     fi
 


### PR DESCRIPTION
calling Node.js stuff is quite costly in terms of cpu time on webOS 7