### PR TITLE
Minor stuff

### DIFF
--- a/services/adapter.ts
+++ b/services/adapter.ts
@@ -34,7 +34,7 @@ export const asyncExecFile: (
 ) => Promise<string> = Bluebird.Promise.promisify(execFile);
 export const asyncStat: (path: string) => Promise<fs.Stats> = Bluebird.Promise.promisify(fs.stat);
 export const asyncUnlink: (path: string) => Promise<void> = Bluebird.Promise.promisify(fs.unlink);
-export const asyncReadFile: (path: string, options?: any) => Promise<Buffer> = Bluebird.Promise.promisify(fs.readFile);
+export const asyncReadFile: (path: string, options?: any) => Promise<Buffer | string> = Bluebird.Promise.promisify(fs.readFile);
 export const asyncWriteFile: (path: string, contents: string, options?: fs.WriteFileOptions) => Promise<void> = Bluebird.Promise.promisify(
   fs.writeFile,
 );

--- a/services/run-js-service
+++ b/services/run-js-service
@@ -1,4 +1,6 @@
-#! /bin/sh
+#!/bin/sh
 
 # :^)
-eval "$(cat /usr/bin/run-js-service | sed 's/^thirdparty_jail=.*/thirdparty_jail=off/')"
+eval "$(sed -e '/^thirdparty_jail=/s/=.*/=off/' \
+            -e '\@/var/luna/preferences/devmode_enabled@s/if /&false \&\& /' \
+            '/usr/bin/run-js-service')"

--- a/services/service.ts
+++ b/services/service.ts
@@ -100,6 +100,15 @@ async function hashFile(filePath: string, algorithm: string): Promise<string> {
 }
 
 /**
+ * Hashes a string with specified algorithm.
+ *
+ * Input should be UTF-8.
+ */
+function hashString(data: string, algorithm: string): string {
+  return createHash(algorithm).update(data, 'utf-8').digest('hex');
+}
+
+/**
  * Elevates a package by name.
  */
 async function elevateService(pkg: string): Promise<void> {
@@ -526,10 +535,13 @@ function runService() {
 
         // RootMyTV v1
         if (await isFile(startDevmode)) {
-          const localChecksum = await hashFile(startDevmode, 'sha256');
           // Warn and return empty string on read error
-          let startDevmodeContents = await asyncReadFile(startDevmode, { encoding: 'utf-8'} )
-            .catch((err) => (console.warn(`reading ${startDevmode} failed: ${err.toString()}`), '')) as string;
+          const startDevmodeContents = (await asyncReadFile(startDevmode, { encoding: 'utf-8' }).catch((err) => {
+            console.warn(`reading ${startDevmode} failed: ${err.toString()}`);
+            return '';
+          })) as string;
+
+          const localChecksum = hashString(startDevmodeContents, 'sha256');
 
           if (localChecksum !== bundledStartupChecksum && updatableChecksums.indexOf(localChecksum) !== -1) {
             await copyScript(bundledStartup, startDevmode);


### PR DESCRIPTION
* Allow Node.js services to be debugged when `/var/luna/preferences/devmode_enabled` isn't a file
* Fix `updateStartupScript` on old webOS (with Node.js <=v0.12.x)
* Only read `start-devmode.sh` once