### PR TITLE
Make some paths relative

### DIFF
--- a/services/service.ts
+++ b/services/service.ts
@@ -497,6 +497,7 @@ function runService() {
           '5caab3681cdd52cc9b59136a180cd0a1ffb98ec39bf571c38c0a4eb528ce13fb',
           'befe927c6f62b87545aaefb4b2648a227b22695fa0f78a228dcacf1fbba11aeb',
           'd914b3b444433bf49ff83c3c0ae0b729cf7544c074e72c23ec24e5f86aaaf4ac',
+          '6215795aed50c11bb7be716cf66326f3657a129143b5edc1b635dab8b8d2fc9f',
         ];
 
         // RootMyTV v2

--- a/services/service.ts
+++ b/services/service.ts
@@ -660,6 +660,7 @@ function runService() {
         env: {
           LD_PRELOAD: '',
           SKIP_ELEVATION: 'true',
+          SERVICE_DIR: __dirname,
         },
         detached: true,
         stdio: ['ignore', 'ignore', 'ignore'],

--- a/services/startup.sh
+++ b/services/startup.sh
@@ -22,6 +22,9 @@ fi
 
 touch "${once}"
 
+# Use default directory if SERVICE_DIR is not provided.
+SERVICE_DIR="${SERVICE_DIR-/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service}"
+
 if [[ -f /var/luna/preferences/webosbrew_failsafe ]]; then
     # In case a reboot occured during last startup - open an emergency telnet
     # server and nag user to actually fix this. (since further reboots could
@@ -73,7 +76,7 @@ else
     # Start sshd
     if [[ -e /var/luna/preferences/webosbrew_sshd_enabled ]]; then
         mkdir -p /var/lib/webosbrew/sshd
-        /media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/bin/dropbear -R 200>&-
+        "${SERVICE_DIR}/bin/dropbear" -R 200>&-
     fi
 
     printf "\033[1;91mNEVER EVER OVERWRITE SYSTEM PARTITIONS LIKE KERNEL, ROOTFS, TVSERVICE.\nYour TV will be bricked, guaranteed! See https://rootmy.tv/warning for more info.\033[0m\n" > /tmp/motd
@@ -122,8 +125,9 @@ else
     fi
 
     # Automatically elevate Homebrew Channel service
-    if [[ -z "${SKIP_ELEVATION}" && -x /media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service ]]; then
-        /media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service
+    elevate_script="${SERVICE_DIR}/elevate-service"
+    if [[ -z "${SKIP_ELEVATION}" && -x "${elevate_script}" ]]; then
+        "${elevate_script}"
     fi
 
     # Run user startup hooks


### PR DESCRIPTION
Currently, it is assumed that the app is installed in `/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service`. This PR makes certain paths either relative or able to be overridden:
* `elevate-service` will now look for `run-js-service` in the same directory as itself and confirm its presence.
* `startup.sh` now looks for a `SERVICE_DIR` environment variable, falling back to the old default if it is not present. (This is needed to find `elevate-service` and `dropbear`.)

`service.ts` now runs `startup.sh` with `SERVICE_DIR` set to the contents of `__dirname`.