### PR TITLE
Add installRoot to /getConfiguration method

### DIFF
--- a/services/service.ts
+++ b/services/service.ts
@@ -30,6 +30,14 @@ import ServiceRemote from './webos-service-remote';
 
 const kHomebrewChannelPackageId = rootAppInfo.id;
 const startDevmode = '/media/cryptofs/apps/usr/palm/services/com.palmdts.devmode.service/start-devmode.sh';
+const homebrewBaseDir = ((): string | null => {
+  try {
+    return path.resolve(__dirname, '../../../../');
+  } catch (err) {
+    console.warn('getting homebrewBaseDir failed:', err);
+    return null;
+  }
+})();
 
 // Maps internal setting field name with filesystem flag name.
 type FlagName = string;
@@ -439,6 +447,7 @@ function runService() {
       const flags = Object.fromEntries(await Promise.all(futureFlags));
       return {
         root: process.getuid() === 0,
+        homebrewBaseDir,
         ...flags,
       };
     }),


### PR DESCRIPTION
The `/getConfiguration` Luna method now returns the root path of Homebrew Channel's installation as `installRoot`. Currently this will be `/media/developer/apps` in the vast majority of cases, but this feature will make it easier to support installation elsewhere in the future.

While it looks like there are no significant changes to `path.resolve()` between Node.js [v0.10.x](https://nodejs.org/docs/latest-v0.10.x/api/path.html#path_path_resolve_from_to), [v0.12.x](https://nodejs.org/docs/latest-v0.12.x/api/path.html#path_path_resolve_from_to), [v8.x](https://nodejs.org/docs/latest-v8.x/api/path.html#path_path_resolve_paths), [v12.x](https://nodejs.org/docs/latest-v12.x/api/path.html#path_path_resolve_paths), and the [current version](https://nodejs.org/api/path.html#pathresolvepaths), I put it inside a `try` block anyway. You never really know with node.

Appears to work:
```json
{"returnValue":true,"root":false,"installRoot":"/media/developer/apps","telnetDisabled":true,"failsafe":false,"sshdEnabled":true,"blockUpdates":true}
```

EDIT: Renamed to `homebrewBaseDir`.