### PR TITLE
Fix warning when repositoriesConfig is missing from localStorage

### DIFF
--- a/frontend/configutils.js
+++ b/frontend/configutils.js
@@ -8,8 +8,14 @@ function getConfig() {
     enableNonfree: false,
   };
 
+  var storedConfig = window.localStorage['repositoriesConfig'];
+
+  if (storedConfig === undefined) {
+    return repositoriesConfig;
+  }
+
   try {
-    var parsed = JSON.parse(window.localStorage['repositoriesConfig']);
+    var parsed = JSON.parse(storedConfig);
     if (parsed.disableDefault !== undefined)
       repositoriesConfig.disableDefault = parsed.disableDefault;
     if (parsed.repositories !== undefined)


### PR DESCRIPTION
Although this probably didn't affect functionality, it was somewhat annoying while debugging.