### PR TITLE
Refactor workflows

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -3,32 +3,32 @@ name: Build Binaries
 on:
   workflow_dispatch:
     inputs:
-        commit:
-          description: 'Commit binaries'
-          required: false
-          default: false
-          type: boolean
+      commit:
+        description: 'Commit binaries'
+        required: false
+        default: false
+        type: boolean
 
 env:
   TARGET_DIR: /tmp/output
-  COMMIT_DIR: ${{github.workspace}}/services/bin
+  COMMIT_DIR: ${{ github.workspace }}/services/bin
   
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Run build-binaries.sh
-      run: ${{github.workspace}}/tools/build-binaries.sh
+      run: ${{ github.workspace }}/tools/build-binaries.sh
       shell: bash
 
     - name: Upload binaries as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: binaries-${{github.run_id}}
-        path: ${{env.TARGET_DIR}}
+        name: binaries-${{ github.run_id }}
+        path: ${{ env.TARGET_DIR }}
         if-no-files-found: error
 
     - name: Commit binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: 'Build IPK and manifest'
+
+on:
+  workflow_call:
+    inputs:
+      fail-on-lint-error:
+        description: 'Fail on lint error'
+        required: false
+        default: false
+        type: boolean
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run lint
+      run: npm run lint
+      continue-on-error: ${{ github.event_name != 'workflow_call' || inputs.fail-on-lint-error }}
+
+    - name: Build frontend
+      run: npm run build -- --production
+
+    - name: Build service
+      run: npm run build-service -- --env production
+
+    - name: Create IPK
+      run: npm run package
+
+    - name: Create manifest
+      run: npm run manifest
+
+    - name: Upload IPK
+      uses: actions/upload-artifact@v4
+      with:
+        name: hbchannel-ipk
+        path: '*.ipk'
+        if-no-files-found: error
+
+    - name: Upload manifest
+      uses: actions/upload-artifact@v4
+      with:
+        name: hbchannel-manifest
+        path: '*.manifest.json'
+        if-no-files-found: error

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,31 +9,6 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-
-    - run: npm ci
-    - run: npm run lint
-    - run: npm run build -- --production
-    - run: npm run build-service -- --env production
-    - run: npm run package
-    - run: 'echo "FILENAME_IPK=$(ls -- *.ipk)" >> "${GITHUB_ENV}"'
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: hbchannel-ipk
-        path: ${{ github.workspace }}/${{ env.FILENAME_IPK }}
+    uses: ./.github/workflows/build.yml
+    with:
+      fail-on-lint-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Build & Test
+name: 'Lint & Build'
 
 on:
   push:
@@ -12,12 +9,11 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -35,9 +31,9 @@ jobs:
     - run: npm run build -- --production
     - run: npm run build-service -- --env production
     - run: npm run package
-    - run: echo FILENAME_IPK=`ls *.ipk` >> $GITHUB_ENV
+    - run: 'echo "FILENAME_IPK=$(ls -- *.ipk)" >> "${GITHUB_ENV}"'
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: hbchannel-ipk
-        path: ${{github.workspace}}/${{ env.FILENAME_IPK }}
+        path: ${{ github.workspace }}/${{ env.FILENAME_IPK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,29 +5,19 @@ on:
     types: [created]
 
 jobs:
-  build-and-release:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  release:
+    needs: build
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
-    - uses: actions/checkout@v4
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
       with:
-        submodules: recursive
-
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-
-    - run: npm ci
-    - run: npm run build -- --production
-    - run: npm run build-service -- --env production
-    - run: npm run package
-    - run: npm run manifest
+        pattern: 'hbchannel-*'
+        merge-multiple: true
 
     - name: Get release
       id: get_release
@@ -35,13 +25,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
-    - name: Upload Release assets
+    - name: Upload IPK
       uses: ncipollo/release-action@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
         name: Release ${{ steps.get_release.outputs.tag_name }}
         allowUpdates: true
         omitNameDuringUpdate: true
         omitBodyDuringUpdate: true
+        omitDraftDuringUpdate: true
         omitPrereleaseDuringUpdate: true
-        artifacts: '*.ipk,org.webosbrew.hbchannel.manifest.json'
+        artifacts: '*.ipk,*.manifest.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build & Release
+name: 'Build & Release'
 
 on:
   release:
@@ -8,15 +8,20 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [20]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
 
-    - name: Use Node.js 18
+    - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: ${{ matrix.node-version }}
 
     - run: npm ci
     - run: npm run build -- --production
@@ -26,7 +31,7 @@ jobs:
 
     - name: Get release
       id: get_release
-      uses: bruceadams/get-release@v1.3.2
+      uses: bruceadams/get-release@74c3d60f5a28f358ccf241a00c9021ea16f0569f
       env:
         GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
I merged the separate build workflows into a single reusable workflow file. I've tested everything except the PR trigger, but that should work the same as pushing to `main`.

I also updated all action and Node.js versions, so we shouldn't have to worry about deprecation warnings for another few years (except the ones in the actions, but I can't do anything about those).