### PR TITLE
Fix service name in sampatcher.py

### DIFF
--- a/services/bin/sampatcher.py
+++ b/services/bin/sampatcher.py
@@ -4,7 +4,7 @@ import re
 import sys
 
 TARGET_STRING      = "luna://com.webos.service.sm/license/apps/getDrmStatus"
-REPLACEMENT_STRING = "luna://tv.rootmy.hbchannel.service/getDrmStatus\0"
+REPLACEMENT_STRING = "luna://org.webosbrew.hbchannel.service/getDrmStatus\0"
 
 sam_pid = int(sys.argv[1])
 

--- a/services/service.ts
+++ b/services/service.ts
@@ -643,6 +643,8 @@ function runService() {
 
   /**
    * Stub service that emulates luna://com.webos.service.sm/license/apps/getDrmStatus
+   *
+   * This is intended to work with sampatcher.py, but it is not currently used.
    */
   type GetDrmStatusPayload = { appId: string };
   service.register(


### PR DESCRIPTION
It appears nobody ever used `sampatcher.py` (at least unmodified), since it has been using the wrong service name ever since it was first committed: `tv.rootmy.hbchannel.service` instead of `org.webosbrew.hbchannel.service`.

I'm not sure `sampatcher.py` (and the associated method in `service.ts`) really belongs in Homebrew Channel, but I'll leave that for another time.