### PR TITLE
Fix /exec on webOS 1

### DIFF
--- a/services/service.ts
+++ b/services/service.ts
@@ -600,7 +600,15 @@ function runService() {
    * Executes a shell command and responds with exit code, stdout and stderr.
    */
   type ExecPayload = { command: string };
-  service.register('exec', (message) => {
+  service.register('exec', (message: Message) => {
+    if (!('command' in message.payload)) {
+      message.respond(makeError('missing "command"'));
+      return;
+    } else if (typeof message.payload['command'] !== 'string') {
+      message.respond(makeError('"command" is not a string'));
+      return;
+    }
+
     const payload = message.payload as ExecPayload;
     child_process.exec(payload.command, { encoding: 'buffer' }, (error, stdout, stderr) => {
       const response = {

--- a/services/service.ts
+++ b/services/service.ts
@@ -647,7 +647,7 @@ function runService() {
   service.register('spawn', (message) => {
     const payload = message.payload as ExecPayload;
     const respond = (event: string, args: Record<string, any>) => message.respond({ event, ...args });
-    const proc = child_process.spawn('/bin/sh', ['-c', payload.command]);
+    const proc = child_process.spawn('/bin/sh', ['-c', '--', payload.command]);
     proc.stdout.on('data', (data) =>
       respond('stdoutData', {
         stdoutString: data.toString(),


### PR DESCRIPTION
Fixes a bug that causes `/exec` to fail on webOS 1. Includes a few other improvements.