### PR TITLE
Handle non-dev mode paths in elevate-service.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
             ],
             "dependencies": {
                 "bluebird": "^3.7.2",
-                "core-js": "^3.12.1",
+                "core-js": "^3.36.0",
                 "dompurify": "^2.2.8",
                 "node-fetch": "^2.6.1 <2.6.8",
                 "progress-stream": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     "dependencies": {
         "bluebird": "^3.7.2",
-        "core-js": "^3.12.1",
+        "core-js": "^3.36.0",
         "dompurify": "^2.2.8",
         "node-fetch": "^2.6.1 <2.6.8",
         "progress-stream": "^2.0.0",


### PR DESCRIPTION
In an effort to reduce the amount of splitting/merging work, this depends on #169 and includes all of the upcoming strict ESLint work on `elevate-service.ts`.