### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,16 @@
 root = true
 
 [*]
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
-[*.js]
+[*.{js,mjs,cjs,ts}]
 indent_style = space
 indent_size = 2
+max_line_length = 140
+quote_type = single
 
 [*.py]
 indent_style = space

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-    "singleQuote": true,
-    "printWidth": 140,
-    "trailingComma": "all"
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,10 +3,10 @@ import ts from 'typescript-eslint';
 
 import jsoncParser from 'jsonc-eslint-parser';
 
-import prettierPlugin from 'eslint-plugin-prettier';
 import importPlugin from 'eslint-plugin-import';
 
-import prettierConfig from 'eslint-config-prettier';
+/* includes the plugin and enables the rules */
+import prettierRecommendedConfig from 'eslint-plugin-prettier/recommended';
 
 import globals from 'globals';
 
@@ -40,16 +40,24 @@ export default ts.config(
   js.configs.recommended,
   ...ts.configs.strictTypeChecked,
   ...airbnbCompat,
-  prettierConfig,
+  prettierRecommendedConfig,
   {
     /* all JS/TS files */
     files: ['**/*.{js,mjs,cjs,ts}'],
+    linterOptions: {
+      /* disable for now */
+      // reportUnusedDisableDirectives: 'warn',
+    },
     plugins: {
-      prettier: prettierPlugin,
       import: importPlugin,
     },
     rules: {
-      'prettier/prettier': ['error'],
+      'prettier/prettier': [
+        'error',
+        {
+          trailingComma: 'all',
+        },
+      ],
       /* allow names that start with _ to be unused */
       '@typescript-eslint/no-unused-vars': [
         'error',
@@ -57,8 +65,8 @@ export default ts.config(
           args: 'all',
           argsIgnorePattern: '^_',
           caughtErrors: 'all',
-          caughtErrorsIgnorePattern: '^_',
           destructuredArrayIgnorePattern: '^_',
+          /* varsIgnorePattern affects catch as well */
           varsIgnorePattern: '^_',
         },
       ],
@@ -115,7 +123,7 @@ export default ts.config(
     },
   },
   {
-    files: ['services/**/*.{js,ts}', 'tools/*.js', 'eslint.config.{js,cjs,mjs}', 'webpack.config.js'],
+    files: ['services/**/*.{js,ts}', 'tools/*.js', 'eslint.config.{js,mjs,cjs}', 'webpack.config.js'],
     /* all of these use node */
     languageOptions: {
       globals: {
@@ -140,13 +148,18 @@ export default ts.config(
   },
   {
     files: ['tools/*.js'],
+    languageOptions: {
+      /* these scripts run during build, so they can use recent Node.js */
+      ecmaVersion: 'latest',
+      sourceType: 'script',
+    },
     rules: {
       /* not sure how to tell it these aren't modules */
       '@typescript-eslint/no-var-requires': 'off',
     },
   },
   {
-    files: ['*.config.{js,cjs,mjs}'],
+    files: ['*.config.{js,mjs,cjs}'],
     rules: {
       /* obviously we need dev dependencies */
       'import/no-extraneous-dependencies': [
@@ -159,7 +172,7 @@ export default ts.config(
     },
   },
   {
-    files: ['eslint.config.{js,cjs,mjs}'],
+    files: ['eslint.config.{js,mjs,cjs}'],
     rules: {
       /* necessary for flat config */
       'import/no-default-export': 'off',
@@ -169,6 +182,13 @@ export default ts.config(
     files: ['webpack.config.js'],
     rules: {
       '@typescript-eslint/no-var-requires': 'off',
+    },
+  },
+  {
+    files: ['babel.config.json', 'tsconfig.json'],
+    rules: {
+      /* has various issues (e.g., forcing arrays/objects onto a single line) */
+      'prettier/prettier': 'off',
     },
   },
 );

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,13 +1,13 @@
 /**
-	Define your enyo/Application kind in this file.
+  Define your enyo/Application kind in this file.
 */
 
 var
-	kind = require('enyo/kind'),
-	Application = require('enyo/Application'),
-	MainView = require('./views/MainView');
+  kind = require('enyo/kind'),
+  Application = require('enyo/Application'),
+  MainView = require('./views/MainView');
 
 module.exports = kind({
-	kind: Application,
-	view: MainView
+  kind: Application,
+  view: MainView
 });

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,7 +1,7 @@
 /**
-	Instantiate your enyo/Application kind in this file.  Note, application
-	rendering should be deferred until the DOM is ready by wrapping it in a
-	call to ready().
+  Instantiate your enyo/Application kind in this file.  Note, application
+  rendering should be deferred until the DOM is ready by wrapping it in a
+  call to ready().
 */
 
 var

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,235 +1,235 @@
 var appinfos = [
-	{
-		id: "com.example.foobar",
-		title: "Example Name",
-		appDescription: "App Description",
-		vendor: "Example Vendor",
-		version: "v0.01",
-		icon: "http://placekitten.com/64/64"
-	},
-	{
-		id: "com.example.blah",
-		title: "Blah Blah",
-		appDescription: "App Description",
-		vendor: "Example Vendor",
-		version: "v0.01",
-		icon: "http://placekitten.com/64/64"
-	},
-	{
-		id: "com.example.abc",
-		title: "Foo Bar",
-		appDescription: "App Description",
-		vendor: "Example Vendor",
-		version: "v0.01",
-		icon: "http://placekitten.com/64/64"
-	},
-	{
-		id: "com.example.def",
-		title: "Foo Bar",
-		appDescription: "App Description",
-		vendor: "Example Vendor",
-		version: "v0.01",
-		icon: "http://placekitten.com/64/64"
-	},
-	{
-		id: "com.example.123",
-		title: "Foo Bar",
-		appDescription: "App Description",
-		vendor: "Example Vendor",
-		version: "v0.01",
-		icon: "http://placekitten.com/64/64"
-	},
-	{
-		id: "com.example.456",
-		title: "Foo Bar",
-		appDescription: "App Description",
-		vendor: "Example Vendor",
-		version: "v0.01",
-		icon: "http://placekitten.com/64/64"
-	},
-	{
-		id: "com.example.789",
-		title: "Foo Bar",
-		appDescription: "App Description",
-		vendor: "Example Vendor",
-		version: "v0.01",
-		icon: "http://placekitten.com/64/64"
-	},
-	{
-		id: "com.example.zed",
-		title: "Foo Bar",
-		appDescription: "App Description",
-		vendor: "Example Vendor",
-		version: "v0.01",
-		icon: "http://placekitten.com/64/64"
-	},
-	{
-		id: "com.example.bbbb",
-		title: "Foo Bar",
-		appDescription: "App Description",
-		vendor: "Example Vendor",
-		version: "v0.01",
-		icon: "http://placekitten.com/64/64"
-	}
+  {
+    id: "com.example.foobar",
+    title: "Example Name",
+    appDescription: "App Description",
+    vendor: "Example Vendor",
+    version: "v0.01",
+    icon: "http://placekitten.com/64/64"
+  },
+  {
+    id: "com.example.blah",
+    title: "Blah Blah",
+    appDescription: "App Description",
+    vendor: "Example Vendor",
+    version: "v0.01",
+    icon: "http://placekitten.com/64/64"
+  },
+  {
+    id: "com.example.abc",
+    title: "Foo Bar",
+    appDescription: "App Description",
+    vendor: "Example Vendor",
+    version: "v0.01",
+    icon: "http://placekitten.com/64/64"
+  },
+  {
+    id: "com.example.def",
+    title: "Foo Bar",
+    appDescription: "App Description",
+    vendor: "Example Vendor",
+    version: "v0.01",
+    icon: "http://placekitten.com/64/64"
+  },
+  {
+    id: "com.example.123",
+    title: "Foo Bar",
+    appDescription: "App Description",
+    vendor: "Example Vendor",
+    version: "v0.01",
+    icon: "http://placekitten.com/64/64"
+  },
+  {
+    id: "com.example.456",
+    title: "Foo Bar",
+    appDescription: "App Description",
+    vendor: "Example Vendor",
+    version: "v0.01",
+    icon: "http://placekitten.com/64/64"
+  },
+  {
+    id: "com.example.789",
+    title: "Foo Bar",
+    appDescription: "App Description",
+    vendor: "Example Vendor",
+    version: "v0.01",
+    icon: "http://placekitten.com/64/64"
+  },
+  {
+    id: "com.example.zed",
+    title: "Foo Bar",
+    appDescription: "App Description",
+    vendor: "Example Vendor",
+    version: "v0.01",
+    icon: "http://placekitten.com/64/64"
+  },
+  {
+    id: "com.example.bbbb",
+    title: "Foo Bar",
+    appDescription: "App Description",
+    vendor: "Example Vendor",
+    version: "v0.01",
+    icon: "http://placekitten.com/64/64"
+  }
 ];
 
 function getRandomInt(max) {
-	return Math.floor(Math.random() * Math.floor(max));
+  return Math.floor(Math.random() * Math.floor(max));
 }
 
 function randFloat(a, b) {
-	return a + (Math.random()*(b-a));
+  return a + (Math.random()*(b-a));
 }
 
 function do_app_modal(appinfo) {
-	window.location.hash = "#appinfo-" + appinfo.id;
-	render_appinfo_modal_dom(appinfo);
+  window.location.hash = "#appinfo-" + appinfo.id;
+  render_appinfo_modal_dom(appinfo);
 }
 
 function close_app_modal() {
-	var modal_container = document.getElementsByClassName("app-modal")[0];
-	modal_container.innerHTML = "";
-	modal_container.style.display = "none";
+  var modal_container = document.getElementsByClassName("app-modal")[0];
+  modal_container.innerHTML = "";
+  modal_container.style.display = "none";
 }
 
 function render_appinfo_modal_dom(appinfo) {
-	var modal_container = document.getElementsByClassName("app-modal")[0];
-	modal_container.innerHTML = "";
-	
-	modal_container.addEventListener("click", function(e) {
-		if (e.target == modal_container) {
-			close_app_modal();
-		}
-	});
-	
-	var modal_div = document.createElement("div");
-	modal_container.appendChild(modal_div);
-	
-	var modal_header = document.createElement("div");
-	modal_header.classList.add("app-modal-header");
-	modal_div.appendChild(modal_header);
-	
-	var app_img =  document.createElement("img");
-	app_img.src = appinfo.icon;
-	modal_header.appendChild(app_img);
-	
-	var app_butt =  document.createElement("button");
-	app_butt.addEventListener("click", function() {
-		alert("TODO: install app :P");
-		logmsg("Error logging test: installed " + appinfo.id);
-		close_app_modal(); // TODO
-	});
-	app_butt.innerText = "Install";
-	modal_header.appendChild(app_butt);
-	
-	var app_title = document.createElement("h2");
-	app_title.innerText = appinfo.title;
-	modal_header.appendChild(app_title)
-	
-	var app_author = document.createElement("p");
-	app_author.innerHTML = "<strong>Developer:</strong>"
-	app_author.insertAdjacentText("beforeend", appinfo.vendor);
-	modal_header.appendChild(app_author);
-	
-	var app_version = document.createElement("p");
-	app_version.innerHTML = "<strong>Version:</strong>"
-	app_version.insertAdjacentText("beforeend", appinfo.version);
-	modal_header.appendChild(app_version);
-	
-	var desctitle = document.createElement("h3");
-	desctitle.innerText = "Description:";
-	modal_div.appendChild(desctitle);
-	
-	var desc = document.createElement("p");
-	desc.innerText = appinfo.appDescription;
-	modal_div.appendChild(desc);
-	
-	modal_container.style.display = "block";
-	console.log("foo");
+  var modal_container = document.getElementsByClassName("app-modal")[0];
+  modal_container.innerHTML = "";
+
+  modal_container.addEventListener("click", function(e) {
+    if (e.target == modal_container) {
+      close_app_modal();
+    }
+  });
+
+  var modal_div = document.createElement("div");
+  modal_container.appendChild(modal_div);
+
+  var modal_header = document.createElement("div");
+  modal_header.classList.add("app-modal-header");
+  modal_div.appendChild(modal_header);
+
+  var app_img =  document.createElement("img");
+  app_img.src = appinfo.icon;
+  modal_header.appendChild(app_img);
+
+  var app_butt =  document.createElement("button");
+  app_butt.addEventListener("click", function() {
+    alert("TODO: install app :P");
+    logmsg("Error logging test: installed " + appinfo.id);
+    close_app_modal(); // TODO
+  });
+  app_butt.innerText = "Install";
+  modal_header.appendChild(app_butt);
+
+  var app_title = document.createElement("h2");
+  app_title.innerText = appinfo.title;
+  modal_header.appendChild(app_title)
+
+  var app_author = document.createElement("p");
+  app_author.innerHTML = "<strong>Developer:</strong>"
+  app_author.insertAdjacentText("beforeend", appinfo.vendor);
+  modal_header.appendChild(app_author);
+
+  var app_version = document.createElement("p");
+  app_version.innerHTML = "<strong>Version:</strong>"
+  app_version.insertAdjacentText("beforeend", appinfo.version);
+  modal_header.appendChild(app_version);
+
+  var desctitle = document.createElement("h3");
+  desctitle.innerText = "Description:";
+  modal_div.appendChild(desctitle);
+
+  var desc = document.createElement("p");
+  desc.innerText = appinfo.appDescription;
+  modal_div.appendChild(desc);
+
+  modal_container.style.display = "block";
+  console.log("foo");
 }
 
 function render_appinfo_dom(appinfo)
 {
-	var card = document.createElement("li");
-	var cardbutt = document.createElement("button");
-	
-	cardbutt.addEventListener("click", function(e) {
-		do_app_modal(appinfo);
-	});
-	
-	var cardimg =  document.createElement("img");
-	cardimg.src = appinfo.icon;
-	cardbutt.appendChild(cardimg);
-	
-	var cardtitle = document.createElement("h3");
-	cardtitle.innerText = appinfo.title;
-	
-	var cardauthor = document.createElement("span");
-	cardauthor.innerHTML = " &mdash; ";
-	cardauthor.innerText += appinfo.vendor;
-	cardtitle.appendChild(cardauthor);
-	
-	cardbutt.appendChild(cardtitle);
-	
-	var carddesc = document.createElement("p");
-	carddesc.innerText = appinfo.appDescription;
-	cardbutt.appendChild(carddesc);
-	
-	card.appendChild(cardbutt)
-	return card;
+  var card = document.createElement("li");
+  var cardbutt = document.createElement("button");
+
+  cardbutt.addEventListener("click", function(e) {
+    do_app_modal(appinfo);
+  });
+
+  var cardimg =  document.createElement("img");
+  cardimg.src = appinfo.icon;
+  cardbutt.appendChild(cardimg);
+
+  var cardtitle = document.createElement("h3");
+  cardtitle.innerText = appinfo.title;
+
+  var cardauthor = document.createElement("span");
+  cardauthor.innerHTML = " &mdash; ";
+  cardauthor.innerText += appinfo.vendor;
+  cardtitle.appendChild(cardauthor);
+
+  cardbutt.appendChild(cardtitle);
+
+  var carddesc = document.createElement("p");
+  carddesc.innerText = appinfo.appDescription;
+  cardbutt.appendChild(carddesc);
+
+  card.appendChild(cardbutt)
+  return card;
 }
 
 function render_applist()
 {
-	var applist = document.getElementsByClassName("applist")[0].children[0];
-	var query = document.getElementsByClassName("searchbox")[0].value.toLowerCase();;
-	applist.innerHTML = "";
-	
-	appinfos.forEach(function(appinfo){
-		if (appinfo.title.toLowerCase().includes(query) || appinfo.appDescription.toLowerCase().includes(query)) {
-			applist.appendChild(render_appinfo_dom(appinfo));
-		}
-	});
+  var applist = document.getElementsByClassName("applist")[0].children[0];
+  var query = document.getElementsByClassName("searchbox")[0].value.toLowerCase();;
+  applist.innerHTML = "";
+
+  appinfos.forEach(function(appinfo){
+    if (appinfo.title.toLowerCase().includes(query) || appinfo.appDescription.toLowerCase().includes(query)) {
+      applist.appendChild(render_appinfo_dom(appinfo));
+    }
+  });
 }
 
 
 window.onload = function()
 {
-	console.log("loaded");
-	
-	var bubbles = document.getElementsByClassName("bubbles")[0];
-	for (var i=0; i<100; i++) {
-		var bubble = document.createElement("div");
-		var scale = randFloat(0.4,1);
-		bubble.classList.add("bubble");
-		bubble.style.left = getRandomInt(1280) + "px";
-		bubble.style.animation = "bubbleup "+(randFloat(3,6)/scale)+"s cubic-bezier(.53,.14,.91,.44) infinite, bubblewobble "+randFloat(2,3)+"s ease-in-out infinite";
-		bubble.style["animation-delay"] = randFloat(0,3)+"s";
-		bubble.style.transform = "scale("+scale+")";
-		bubbles.appendChild(bubble);
-	}
-	
-	var searchBox = document.getElementsByClassName("searchbox")[0];
-	
-	searchBox.addEventListener("input", function(e) {
-		console.log(e.target.value);
-		render_applist();
-	});
-	
-	render_applist();
+  console.log("loaded");
+
+  var bubbles = document.getElementsByClassName("bubbles")[0];
+  for (var i=0; i<100; i++) {
+    var bubble = document.createElement("div");
+    var scale = randFloat(0.4,1);
+    bubble.classList.add("bubble");
+    bubble.style.left = getRandomInt(1280) + "px";
+    bubble.style.animation = "bubbleup "+(randFloat(3,6)/scale)+"s cubic-bezier(.53,.14,.91,.44) infinite, bubblewobble "+randFloat(2,3)+"s ease-in-out infinite";
+    bubble.style["animation-delay"] = randFloat(0,3)+"s";
+    bubble.style.transform = "scale("+scale+")";
+    bubbles.appendChild(bubble);
+  }
+
+  var searchBox = document.getElementsByClassName("searchbox")[0];
+
+  searchBox.addEventListener("input", function(e) {
+    console.log(e.target.value);
+    render_applist();
+  });
+
+  render_applist();
 }
 
 function logmsg(str) {
-	document.getElementById("log-window").innerText += str + "\n";
+  document.getElementById("log-window").innerText += str + "\n";
 }
 
 window.onerror = function myErrorHandler(errorMsg, url, lineNumber) {
-	logmsg("[!] JS Error on line " + lineNumber + ": " + errorMsg);
-	return false;
+  logmsg("[!] JS Error on line " + lineNumber + ": " + errorMsg);
+  return false;
 }
 
 window.onhashchange = function() {
-	if (window.location.hash == "") {
-		close_app_modal();
-	}
+  if (window.location.hash == "") {
+    close_app_modal();
+  }
 }

--- a/services/adapter.ts
+++ b/services/adapter.ts
@@ -21,9 +21,9 @@ fetch.Promise = Bluebird.Promise;
 
 // Sadly these need to be manually typed according to
 // https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
-// since types infered from Bluebird.Promise.promisify are wrong.
-// @ts-expect-error
+// since types inferred from Bluebird.Promise.promisify are wrong.
 export const asyncPipeline: (
+  arg1: NodeJS.ReadableStream,
   ...args: ReadonlyArray<NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream>
 ) => Promise<void> = Bluebird.Promise.promisify(pipeline);
 export const asyncExecFile: (

--- a/services/bin/sampatcher.py
+++ b/services/bin/sampatcher.py
@@ -11,24 +11,24 @@ sam_pid = int(sys.argv[1])
 memfile = open("/proc/%d/mem" % sam_pid, "w+")
 
 for mapping in open("/proc/%d/maps" % sam_pid, "r").readlines():
-	start_addr, end_addr, perms = re.match(r"([0-9a-f]+)\-([0-9a-f]+)\s(\S+)\s", mapping).groups()
-	if not perms.startswith("r"):
-		continue
-	start_addr = int(start_addr, 16)
-	end_addr = int(end_addr, 16)
-	map_size = end_addr - start_addr
-	
-	memfile.seek(start_addr)
-	buf = memfile.read(map_size)
-	
-	if TARGET_STRING in buf:
-		print("Found target string!")
-		addr = start_addr + buf.index(TARGET_STRING)
-		memfile.seek(addr)
-		memfile.write(REPLACEMENT_STRING)
-		memfile.close()
-		print("Replaced target string!")
-		break
+    start_addr, end_addr, perms = re.match(r"([0-9a-f]+)\-([0-9a-f]+)\s(\S+)\s", mapping).groups()
+    if not perms.startswith("r"):
+        continue
+    start_addr = int(start_addr, 16)
+    end_addr = int(end_addr, 16)
+    map_size = end_addr - start_addr
+
+    memfile.seek(start_addr)
+    buf = memfile.read(map_size)
+
+    if TARGET_STRING in buf:
+        print("Found target string!")
+        addr = start_addr + buf.index(TARGET_STRING)
+        memfile.seek(addr)
+        memfile.write(REPLACEMENT_STRING)
+        memfile.close()
+        print("Replaced target string!")
+        break
 else:
-	print("ERROR: Failed to find target string")
+    print("ERROR: Failed to find target string")
 

--- a/services/service.ts
+++ b/services/service.ts
@@ -467,13 +467,13 @@ function runService(): void {
       // and its services (since webOS 4.x) are killed using SIGKILL (9) signal.
       // In order to retain some part of our service still running as root
       // during upgrade we fork off our process and do self-update installation
-      // in there. After a successful install we relevate the service and exit.
+      // in there. After a successful install we re-elevate the service and exit.
       // Exiting cleanly is an important part, since forked process retains open
       // luna bus socket, and thus a new service will not be able to launch
       // until we do that.
       //
-      // If reelevation fails for some reason the service should still be
-      // reelevated on reboot on devices with persistent autostart hooks (since
+      // If re-elevation fails for some reason the service should still be
+      // re-elevated on reboot on devices with persistent autostart hooks (since
       // we launch elevate-service in startup.sh script)
       if (runningAsRoot && isRecord(pkginfo) && pkginfo['Package'] === kHomebrewChannelPackageId) {
         message.respond({ statusText: 'Self-update…' });

--- a/services/webos-service-remote/execbus.js
+++ b/services/webos-service-remote/execbus.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-classes-per-file, no-underscore-dangle */
+/* eslint-disable max-classes-per-file */
 import { EventEmitter } from 'events';
 import { spawn } from 'child_process';
 import { asyncExecFile } from '../adapter';
@@ -50,7 +50,6 @@ export default class Handle {
         stdout += data.toString();
         let searchPos = 0;
         let breakPos = 0;
-        // eslint-disable-next-line no-cond-assign
         while ((breakPos = stdout.indexOf('\n', searchPos)) > 0) {
           const line = stdout.substring(searchPos, breakPos).trim();
           request.emit('response', Message.constructBody(line, true));

--- a/services/webos-service-remote/message.js
+++ b/services/webos-service-remote/message.js
@@ -24,7 +24,6 @@ export default class Message {
   }
 
   //* respond to a message, with a JSON-compatible object
-  // eslint-disable-next-line no-unused-vars
   respond() {
     throw new Error('Not implemented');
   }

--- a/tools/doas/doas.c
+++ b/tools/doas/doas.c
@@ -9,26 +9,26 @@ int main(int argc, char *argv[], char *envp[])
 		printf("USAGE: %s uid gid command\n", argv[0]);
 		return -1;
 	}
-	
+
 	uid_t uid = atoi(argv[1]);
 	uid_t gid = atoi(argv[2]);
-	
+
 	// Break out of jail, if we're in one
 	if (chroot("/proc/1/root/") != 0) {
 		perror("doas: chroot");
 		return -1;
 	}
-	
+
 	if (setresgid(gid, gid, gid) != 0) {
 		perror("doas: setresgid");
 		return -1;
 	}
-	
+
 	if (setresuid(uid, uid, uid) != 0) {
 		perror("doas: setresuid");
 		return -1;
 	}
-	
+
 	execve(argv[3], &argv[3], envp);
 	perror("doas: execve"); // execve only returns on error
 	return -1;


### PR DESCRIPTION
* Removed `.prettierrc`. Settings were mostly moved to `.editorconfig`, but one ended up in `eslint.config.mjs`. Prettier still takes them into account.
* Tweaked some ESLint and EditorConfig settings. The JS settings in `.editorconfig` now cover TS files and additional JS extensions.
* Removed a few unnecessary ESLint disable comments. I used `reportUnusedDisableDirectives`, but I mostly left anything that would be relevant if the associated rule were enabled. The ones I removed were along the lines of `no-unused-vars` on a line with no variables.
* Modified a type to eliminate a suppressed TypeScript error in `adapter.ts`.
* Fixed a handful of spelling mistakes.
* Replaced tabs being used for indentation with spaces. The entire repo is now consistently indented with spaces. I also removed extraneous whitespace at the end of a few lines.

I don't think any of this will really affect the code that ends up in the IPK.