### PR TITLE
Populate Native Apps' Jailer on Install

### DIFF
--- a/services/better-jail.ts
+++ b/services/better-jail.ts
@@ -1,0 +1,6 @@
+import { asyncExecFile } from './adapter';
+
+export async function buildBetterJail(id: string, appDir: string) {
+  // Populate the jail with `native` instead of `native_devmode`, to gain higher privileges
+  await asyncExecFile('jailer', ['-t', 'native', '-p', appDir, '-i', id, '/bin/true']);
+}

--- a/services/service.ts
+++ b/services/service.ts
@@ -13,6 +13,7 @@ import Service, { Message } from 'webos-service';
 
 import { asyncStat, asyncExecFile, asyncPipeline, asyncUnlink, asyncWriteFile, asyncReadFile, asyncChmod, asyncMkdir } from './adapter';
 import { fetchWrapper } from './fetch-wrapper';
+import { buildBetterJail } from './better-jail';
 
 import rootAppInfo from '../appinfo.json';
 import serviceInfo from './services.json';
@@ -406,8 +407,14 @@ function runService(): void {
     return serviceRemote as Service;
   }
 
-  async function getAppInfo(appId: string): Promise<Record<string, any>> {
-    const appList = await asyncCall<{ apps: { id: string }[] }>(
+  interface AppInfo {
+    id: string;
+    title: string;
+    type: string;
+    folderPath: string;
+  }
+  async function getAppInfo(appId: string): Promise<AppInfo> {
+    const appList = await asyncCall<{ apps: AppInfo[] }>(
       getInstallerService(),
       'luna://com.webos.applicationManager/dev/listApps',
       {},
@@ -491,7 +498,12 @@ function runService(): void {
 
       try {
         const appInfo = await getAppInfo(installedPackageId);
-        await createToast(`Application installed: ${appInfo['title']}`, service);
+        if (appInfo.type === 'native') {
+          await createToast(`Updating jailer config for ${appInfo.title}…`, service);
+          await buildBetterJail(appInfo.id, appInfo.folderPath)
+            .catch((err) => console.warn('jailer execution failed:', err));
+        }
+        await createToast(`Application installed: ${appInfo.title}`, service);
       } catch (err: unknown) {
         console.warn('appinfo fetch failed:', err);
         await createToast(`Application installed: ${installedPackageId}`, service);

--- a/services/service.ts
+++ b/services/service.ts
@@ -498,7 +498,7 @@ function runService(): void {
 
       try {
         const appInfo = await getAppInfo(installedPackageId);
-        if (appInfo.type === 'native') {
+        if (appInfo.type === 'native' && runningAsRoot) {
           await createToast(`Updating jailer config for ${appInfo.title}…`, service);
           await buildBetterJail(appInfo.id, appInfo.folderPath)
             .catch((err) => console.warn('jailer execution failed:', err));

--- a/services/service.ts
+++ b/services/service.ts
@@ -413,9 +413,11 @@ function runService(): void {
     type: string;
     folderPath: string;
   }
-  type AppsResponse = { apps: AppInfo[] };
+  interface AppsList {
+    apps: AppInfo[];
+  }
   async function getAppInfo(appId: string): Promise<AppInfo> {
-    const appList = await asyncCall<AppsResponse>(getInstallerService(), 'luna://com.webos.applicationManager/dev/listApps', {});
+    const appList = await asyncCall<AppsList>(getInstallerService(), 'luna://com.webos.applicationManager/dev/listApps', {});
     const appInfo = appList.apps.find((app) => app.id === appId);
     if (!appInfo) throw new Error(`Invalid appId, or unsupported application type: ${appId}`);
     return appInfo;

--- a/services/service.ts
+++ b/services/service.ts
@@ -413,12 +413,9 @@ function runService(): void {
     type: string;
     folderPath: string;
   }
+  type AppsResponse = { apps: AppInfo[] };
   async function getAppInfo(appId: string): Promise<AppInfo> {
-    const appList = await asyncCall<{ apps: AppInfo[] }>(
-      getInstallerService(),
-      'luna://com.webos.applicationManager/dev/listApps',
-      {},
-    );
+    const appList = await asyncCall<AppsResponse>(getInstallerService(), 'luna://com.webos.applicationManager/dev/listApps', {});
     const appInfo = appList.apps.find((app) => app.id === appId);
     if (!appInfo) throw new Error(`Invalid appId, or unsupported application type: ${appId}`);
     return appInfo;
@@ -500,8 +497,9 @@ function runService(): void {
         const appInfo = await getAppInfo(installedPackageId);
         if (appInfo.type === 'native' && runningAsRoot) {
           await createToast(`Updating jailer config for ${appInfo.title}…`, service);
-          await buildBetterJail(appInfo.id, appInfo.folderPath)
-            .catch((err) => console.warn('jailer execution failed:', err));
+          await buildBetterJail(appInfo.id, appInfo.folderPath).catch((err) => {
+            console.warn('jailer execution failed:', err);
+          });
         }
         await createToast(`Application installed: ${appInfo.title}`, service);
       } catch (err: unknown) {


### PR DESCRIPTION
This PR has similar effect as #201, but doesn't fetch any external resource.

For 2019 models with k5lp SoC, default jailer config (`native_devmode`) misses `/dev/rtkmem` causing A/V related apps to crash (e.g. Kodi, Moonlight).

When jailer starts with a different type, device nodes in that jailer config will be created, and persisted even after starting with other types or reboot.

So we start the jailer once with `native` type, creating required device nodes, and the issue gets fixed. There seems to be no negative side effect, as mounting points will not change.