### PR TITLE
Revert "Populate Native Apps' Jailer on Install"

### DIFF
--- a/services/better-jail.ts
+++ b/services/better-jail.ts
@@ -1,6 +1,0 @@
-import { asyncExecFile } from './adapter';
-
-export async function buildBetterJail(id: string, appDir: string) {
-  // Populate the jail with `native` instead of `native_devmode`, to gain higher privileges
-  await asyncExecFile('jailer', ['-t', 'native', '-p', appDir, '-i', id, '/bin/true']);
-}

--- a/services/service.ts
+++ b/services/service.ts
@@ -406,12 +406,17 @@ function runService(): void {
     return serviceRemote as Service;
   }
 
-  async function getAppInfo(appId: string): Promise<Record<string, any>> {
-    const appList = await asyncCall<{ apps: { id: string }[] }>(
-      getInstallerService(),
-      'luna://com.webos.applicationManager/dev/listApps',
-      {},
-    );
+  interface AppInfo {
+    id: string;
+    title: string;
+    type: string;
+    folderPath: string;
+  }
+  interface AppsList {
+    apps: AppInfo[];
+  }
+  async function getAppInfo(appId: string): Promise<AppInfo> {
+    const appList = await asyncCall<AppsList>(getInstallerService(), 'luna://com.webos.applicationManager/dev/listApps', {});
     const appInfo = appList.apps.find((app) => app.id === appId);
     if (!appInfo) throw new Error(`Invalid appId, or unsupported application type: ${appId}`);
     return appInfo;
@@ -491,7 +496,7 @@ function runService(): void {
 
       try {
         const appInfo = await getAppInfo(installedPackageId);
-        await createToast(`Application installed: ${appInfo['title']}`, service);
+        await createToast(`Application installed: ${appInfo.title}`, service);
       } catch (err: unknown) {
         console.warn('appinfo fetch failed:', err);
         await createToast(`Application installed: ${installedPackageId}`, service);

--- a/services/service.ts
+++ b/services/service.ts
@@ -13,7 +13,6 @@ import Service, { Message } from 'webos-service';
 
 import { asyncStat, asyncExecFile, asyncPipeline, asyncUnlink, asyncWriteFile, asyncReadFile, asyncChmod, asyncMkdir } from './adapter';
 import { fetchWrapper } from './fetch-wrapper';
-import { buildBetterJail } from './better-jail';
 
 import rootAppInfo from '../appinfo.json';
 import serviceInfo from './services.json';
@@ -407,17 +406,12 @@ function runService(): void {
     return serviceRemote as Service;
   }
 
-  interface AppInfo {
-    id: string;
-    title: string;
-    type: string;
-    folderPath: string;
-  }
-  interface AppsList {
-    apps: AppInfo[];
-  }
-  async function getAppInfo(appId: string): Promise<AppInfo> {
-    const appList = await asyncCall<AppsList>(getInstallerService(), 'luna://com.webos.applicationManager/dev/listApps', {});
+  async function getAppInfo(appId: string): Promise<Record<string, any>> {
+    const appList = await asyncCall<{ apps: { id: string }[] }>(
+      getInstallerService(),
+      'luna://com.webos.applicationManager/dev/listApps',
+      {},
+    );
     const appInfo = appList.apps.find((app) => app.id === appId);
     if (!appInfo) throw new Error(`Invalid appId, or unsupported application type: ${appId}`);
     return appInfo;
@@ -497,13 +491,7 @@ function runService(): void {
 
       try {
         const appInfo = await getAppInfo(installedPackageId);
-        if (appInfo.type === 'native' && runningAsRoot) {
-          await createToast(`Updating jailer config for ${appInfo.title}…`, service);
-          await buildBetterJail(appInfo.id, appInfo.folderPath).catch((err) => {
-            console.warn('jailer execution failed:', err);
-          });
-        }
-        await createToast(`Application installed: ${appInfo.title}`, service);
+        await createToast(`Application installed: ${appInfo['title']}`, service);
       } catch (err: unknown) {
         console.warn('appinfo fetch failed:', err);
         await createToast(`Application installed: ${installedPackageId}`, service);


### PR DESCRIPTION
Reverts webosbrew/webos-homebrew-channel#202

Unfortunately, for some models running webOS 8, this hack doesn't fix anything. Without proper jailer config, native apps won't be able to see external storage at all.

Since this is not a universal solution, I'll make an init script instead, and revert this feature.