### PR TITLE
Fixed App Icon Sizing for HD (720p) Resolution

### DIFF
--- a/frontend/views/BrowserPanel.js
+++ b/frontend/views/BrowserPanel.js
@@ -67,7 +67,7 @@ var AppListItem = kind({
       kind: MoonImage,
       name: 'img',
       // placeholder: EnyoImage.placeholder,
-      style: 'width: 100px; height: 100px; float: left; padding-right: 20px; padding-top: 5px',
+      style: 'width: 4.25rem; height: 4.25rem; float: left; padding-right: 1rem; padding-top: 0.25rem',
       sizing: 'contain',
     },
     {name: 'caption', classes: 'caption', kind: Marquee.Text},

--- a/frontend/views/DetailsPanel.js
+++ b/frontend/views/DetailsPanel.js
@@ -70,7 +70,7 @@ module.exports = kind({
     {
       kind: MoonImage,
       name: 'headerImage',
-      style: 'width: 100px; height: 100px; float: left; padding-right: 20px; padding-top: 5px',
+      style: 'width: 5rem; height: 5rem; float: left; padding-right: 1rem; padding-top: 0.25rem;',
       sizing: 'contain',
     },
   ],


### PR DESCRIPTION
On some low-end models, UI is rendered in 720p, causing app icons to be clipped as they are too big.

This PR uses suggested sizing unit for Enyo, to provide a consistent look for all resolutions.

![webos-dev-tmp-3e4149ff-08dc-4951-92b5-e300ecb1e65c](https://github.com/user-attachments/assets/96c6756e-e50c-422e-a86b-92f4b5ec65be)


After:
![webos-dev-tmp-0ce132b5-38ef-403b-8850-e3f969f5298b](https://github.com/user-attachments/assets/93c553c5-281d-4be6-9e1b-bcde4b629f37)

---

While on FHD UI, it should be the same:

Before:
![webos-dev-tmp-7c2d6507-5767-4ee4-9548-f06f191a0eec](https://github.com/user-attachments/assets/5795e633-214e-4b9c-abbc-4bd574d54a24)

After:
![webos-dev-tmp-ae53c2ef-916f-4fd2-acc7-815475e7c017](https://github.com/user-attachments/assets/df4cb11a-8b72-45d7-863a-50f06e7da1a6)

