### PR TITLE
fix(service): properly wrap luna errors in asyncCall

### DIFF
--- a/services/service.ts
+++ b/services/service.ts
@@ -70,8 +70,13 @@ function asyncCall<T extends Record<string, any>>(srv: Service, uri: string, arg
     srv.call(uri, args, ({ payload }) => {
       if (payload['returnValue']) {
         resolve(payload as T);
+        return;
+      }
+
+      if ('errorText' in payload) {
+        reject(new Error(`Luna Error: ${payload['errorText']}`));
       } else {
-        reject(payload);
+        reject(new Error(`Luna Error: ${JSON.stringify(payload, null, 2)}`));
       }
     });
   });


### PR DESCRIPTION
if luna callee returns an error (`returnValue` is `false`), [`asyncCall`](https://github.com/webosbrew/webos-homebrew-channel/blob/92fcf9fef7ce08dbeae3b0616df8d0c75c11f0b3/services/service.ts#L68) throws the raw payload object instead of an Error.

further down the call stack, [`tryRespond`](https://github.com/webosbrew/webos-homebrew-channel/blob/92fcf9fef7ce08dbeae3b0616df8d0c75c11f0b3/services/service.ts#L382) catches this value and calls [`assertNodeError`](https://github.com/webosbrew/webos-homebrew-channel/blob/92fcf9fef7ce08dbeae3b0616df8d0c75c11f0b3/services/service.ts#L62).

`assertNodeError` checks whether the argument's prototype is `Error` and throws a new error if a raw payload is passed.

as a result, this leads to an unhandled promise rejection. HBC's Luna service does not send a response to client, which causes request calls to hang indefinitely.

---

this PR fixes promise rejection.