### PR TITLE
quirks for autostart on ancient webOS (<4.0)

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -9,9 +9,5 @@
     "main": "index.html",
     "iconColor": "#cf0652",
     "type": "web",
-    "appDescription": "webOS Homebrew installer",
-    "previewMetadata": {
-        "targetEndpoint": "luna://org.webosbrew.hbchannel.service/autostart",
-        "sourceEndpoint": "@PREVIEW.ENDPOINT.SOURCE_LOCAL_STOREAPP"
-    }
+    "appDescription": "webOS Homebrew installer"
 }

--- a/services/fake-activity-manager.ts
+++ b/services/fake-activity-manager.ts
@@ -3,22 +3,24 @@ import type { ActivityManager } from 'webos-service';
 type PublicAM = Pick<ActivityManager, 'create' | 'adopt' | 'complete'>;
 
 /**
- * for each request, `webos-service` _create_s an activity, waits for acknowledgment from ActivityManager,
- * and then runs method handler. eventually, the activity is _complete_d.
+ * for each request, `webos-service` creates an activity, waits for acknowledgment from ActivityManager,
+ * and then runs method handler. eventually, activity completes.
  *
  * if response from *any* call contains `$activity` field, `webos-service` attempts to _adopt_ it.
  * unfortunately, this also removes the activity from persistent DB.
  *
  * instead of patching the external library behavior, we use a stub.
  *
- * ActivityManager stub is still used to terminate service if it is idling for a while
+ * ActivityManager stub is still used to terminate service if it is idling for `ttlSeconds`.
  */
 class FakeActivityManager implements PublicAM {
   private _counter: number = 0;
 
   private _idleTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(private readonly _ttlSeconds: number) {}
+  constructor(private readonly _ttlSeconds: number) {
+    this._idleTimer = setTimeout(this.quit.bind(this), this._ttlSeconds * 1000);
+  }
 
   create(_activity: any, callback?: (payload: any) => void) {
     this.acquire();

--- a/services/fake-activity-manager.ts
+++ b/services/fake-activity-manager.ts
@@ -39,6 +39,10 @@ class FakeActivityManager implements PublicAM {
 
   private acquire() {
     this._counter++;
+
+    if (this._idleTimer !== null) {
+      clearTimeout(this._idleTimer);
+    }
   }
 
   private release() {
@@ -46,8 +50,6 @@ class FakeActivityManager implements PublicAM {
 
     if (this._counter === 0) {
       this._idleTimer = setTimeout(this.quit.bind(this), this._ttlSeconds * 1000);
-    } else if (this._idleTimer !== null) {
-      clearTimeout(this._idleTimer);
     }
   }
 

--- a/services/fake-activity-manager.ts
+++ b/services/fake-activity-manager.ts
@@ -1,0 +1,61 @@
+import type { ActivityManager } from 'webos-service';
+
+type PublicAM = Pick<ActivityManager, 'create' | 'adopt' | 'complete'>;
+
+/**
+ * for each request, `webos-service` _create_s an activity, waits for acknowledgment from ActivityManager,
+ * and then runs method handler. eventually, the activity is _complete_d.
+ *
+ * if response from *any* call contains `$activity` field, `webos-service` attempts to _adopt_ it.
+ * unfortunately, this also removes the activity from persistent DB.
+ *
+ * instead of patching the external library behavior, we use a stub.
+ *
+ * ActivityManager stub is still used to terminate service if it is idling for a while
+ */
+class FakeActivityManager implements PublicAM {
+  private _counter: number = 0;
+
+  private _idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly _ttlSeconds: number) {}
+
+  create(_activity: any, callback?: (payload: any) => void) {
+    this.acquire();
+    callback?.({ returnValue: true });
+  }
+
+  adopt(_activity: any, callback?: (payload: any) => void) {
+    this.acquire();
+    callback?.({ payload: { returnValue: true } });
+  }
+
+  complete(_activity: any, callback?: (payload: any) => void) {
+    this.release();
+    callback?.({ returnValue: true });
+  }
+
+  private acquire() {
+    this._counter++;
+  }
+
+  private release() {
+    this._counter--;
+
+    if (this._counter === 0) {
+      this._idleTimer = setTimeout(this.quit.bind(this), this._ttlSeconds * 1000);
+    } else if (this._idleTimer !== null) {
+      clearTimeout(this._idleTimer);
+    }
+  }
+
+  private quit() {
+    console.log('quitting on next tick');
+    process.nextTick(() => process.exit(0));
+  }
+}
+
+export function createFakeActivityManager(ttlSeconds: number) {
+  // types include many props that should not actually be public
+  return new FakeActivityManager(ttlSeconds) as unknown as ActivityManager;
+}

--- a/services/fake-activity-manager.ts
+++ b/services/fake-activity-manager.ts
@@ -1,4 +1,11 @@
+import type Service from 'webos-service';
 import type { ActivityManager } from 'webos-service';
+
+declare module 'webos-service/service' {
+  interface Service {
+    unregister(): void;
+  }
+}
 
 type PublicAM = Pick<ActivityManager, 'create' | 'adopt' | 'complete'>;
 
@@ -13,12 +20,15 @@ type PublicAM = Pick<ActivityManager, 'create' | 'adopt' | 'complete'>;
  *
  * ActivityManager stub is still used to terminate service if it is idling for `ttlSeconds`.
  */
-class FakeActivityManager implements PublicAM {
+export class FakeActivityManager implements PublicAM {
   private _counter: number = 0;
 
   private _idleTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(private readonly _ttlSeconds: number) {
+  constructor(
+    private _service: Service | null = null,
+    private _ttlSeconds: number = 30,
+  ) {
     this._idleTimer = setTimeout(this.quit.bind(this), this._ttlSeconds * 1000);
   }
 
@@ -35,6 +45,15 @@ class FakeActivityManager implements PublicAM {
   complete(_activity: any, callback?: (payload: any) => void) {
     this.release();
     callback?.({ returnValue: true });
+  }
+
+  setService(service: Service) {
+    // types include many props that should not actually be public
+    this._service = service;
+  }
+
+  cast() {
+    return this as unknown as ActivityManager;
   }
 
   private acquire() {
@@ -55,11 +74,9 @@ class FakeActivityManager implements PublicAM {
 
   private quit() {
     console.log('quitting on next tick');
-    process.nextTick(() => process.exit(0));
-  }
-}
 
-export function createFakeActivityManager(ttlSeconds: number) {
-  // types include many props that should not actually be public
-  return new FakeActivityManager(ttlSeconds) as unknown as ActivityManager;
+    process.nextTick(() => process.exit(0));
+
+    this._service?.unregister();
+  }
 }

--- a/services/fake-activity-manager.ts
+++ b/services/fake-activity-manager.ts
@@ -2,6 +2,7 @@ import type Service from 'webos-service';
 import type { ActivityManager } from 'webos-service';
 
 declare module 'webos-service/service' {
+  // eslint-disable-next-line @typescript-eslint/no-shadow
   interface Service {
     unregister(): void;
   }
@@ -20,7 +21,7 @@ type PublicAM = Pick<ActivityManager, 'create' | 'adopt' | 'complete'>;
  *
  * ActivityManager stub is still used to terminate service if it is idling for `ttlSeconds`.
  */
-export class FakeActivityManager implements PublicAM {
+export default class FakeActivityManager implements PublicAM {
   private _counter: number = 0;
 
   private _idleTimer: ReturnType<typeof setTimeout> | null = null;

--- a/services/service.ts
+++ b/services/service.ts
@@ -21,7 +21,7 @@ import ServiceRemote from './webos-service-remote';
 import { createFakeActivityManager } from './fake-activity-manager';
 
 const homebrewChannelPackageId = rootAppInfo.id;
-const autostartActivityName = `${homebrewChannelPackageId}.autostart`;
+const autostartActivityName = `${homebrewChannelPackageId}.service.autostart`;
 const startDevmode = '/media/cryptofs/apps/usr/palm/services/com.palmdts.devmode.service/start-devmode.sh';
 const homebrewBaseDir = ((): string | null => {
   try {

--- a/services/service.ts
+++ b/services/service.ts
@@ -18,7 +18,7 @@ import rootAppInfo from '../appinfo.json';
 import serviceInfo from './services.json';
 import { makeError, makeSuccess } from './protocol';
 import ServiceRemote from './webos-service-remote';
-import { createFakeActivityManager } from './fake-activity-manager';
+import { FakeActivityManager } from './fake-activity-manager';
 
 const homebrewChannelPackageId = rootAppInfo.id;
 const autostartActivityName = `${homebrewChannelPackageId}.service.autostart`;
@@ -397,8 +397,11 @@ function tryRespond<T extends Record<string, any>>(runner: (message: Message) =>
 }
 
 function runService(): void {
-  const service = new Service(serviceInfo.id, createFakeActivityManager(30));
+  const fakeAM = new FakeActivityManager();
+  const service = new Service(serviceInfo.id, fakeAM.cast());
   const serviceRemote = new ServiceRemote();
+
+  fakeAM.setService(service);
 
   // legacy webOS (pre-ACG) used two luna buses: private and public.
   // by default, public handle is used for outbound calls.

--- a/services/service.ts
+++ b/services/service.ts
@@ -18,7 +18,7 @@ import rootAppInfo from '../appinfo.json';
 import serviceInfo from './services.json';
 import { makeError, makeSuccess } from './protocol';
 import ServiceRemote from './webos-service-remote';
-import { FakeActivityManager } from './fake-activity-manager';
+import FakeActivityManager from './fake-activity-manager';
 
 const homebrewChannelPackageId = rootAppInfo.id;
 const autostartActivityName = `${homebrewChannelPackageId}.service.autostart`;

--- a/services/service.ts
+++ b/services/service.ts
@@ -496,7 +496,7 @@ function runService(): void {
         await createToast('Performing self-update...', service);
 
         child_process.fork(__filename, ['self-update', targetPath]);
-        service.activityManager.idleTimeout = 1;
+        setTimeout(() => process.exit(0), 1000);
         return { statusText: 'Self-update' };
       }
 

--- a/services/service.ts
+++ b/services/service.ts
@@ -330,6 +330,7 @@ async function registerActivity(service: Service): Promise<void> {
       foreground: true,
       persist: true,
       continuous: true,
+      explicit: true,
     },
     trigger: {
       method: 'luna://com.webos.bootManager/getBootStatus',

--- a/services/service.ts
+++ b/services/service.ts
@@ -31,7 +31,6 @@ const homebrewBaseDir = ((): string | null => {
     return null;
   }
 })();
-const isLegacyBus = fs.existsSync('/var/run/ls2/ls-hubd.private.pid');
 
 const nodeVersion = (() => {
   try {
@@ -794,15 +793,16 @@ function runService(): void {
   service.register(
     'autostart',
     tryRespond(async (message: Message) => {
-      const calledByActivity = /^com\.(?:palm|webos)(?:\.service)?\.activitymanager$/.test(
+      const calledByActivityManager = /^com\.(?:palm|webos)(?:\.service)?\.activitymanager$/.test(
         (message.ls2Message as { senderServiceName: () => string }).senderServiceName(),
       );
-
       // legacy ActivityManager does not expire/satisfy activity after invoking the callback
       // to prevent the service from restarting over and over, manually pause the activity
       // it's done without await to avoid slowing down autostart
-      if (isLegacyBus && calledByActivity) {
+      if (calledByActivityManager) {
         pauseActivity(service).catch((payload) => {
+          // /pause will complain on modern webOS about invalid activity state transition
+          // it's safe to ignore, activity is still persisted in db
           console.warn('failed to pause autostart activity', payload);
         });
       }
@@ -836,7 +836,7 @@ function runService(): void {
       });
 
       // frontend calls /autostart on launch
-      if (!calledByActivity) {
+      if (!calledByActivityManager) {
         try {
           await registerActivity(service);
         } catch (e) {

--- a/services/service.ts
+++ b/services/service.ts
@@ -322,7 +322,7 @@ async function removePackage(packageId: string, service: Service): Promise<void>
 /**
  * Register activity to call /autostart on boot
  */
-async function registerActivity(service: Service): Promise<void> {
+function registerActivity(service: Service): Promise<Record<string, any>> {
   const activity = {
     name: autostartActivityName,
     description: 'Start Homebrew Channel service on boot',
@@ -354,7 +354,7 @@ async function registerActivity(service: Service): Promise<void> {
     replace: true,
   };
 
-  await asyncCall(service, 'luna://com.palm.activitymanager/create', spec);
+  return asyncCall(service, 'luna://com.palm.activitymanager/create', spec);
 }
 
 async function pauseActivity(service: Service, activityName: string = autostartActivityName) {
@@ -785,7 +785,7 @@ function runService(): void {
 
   service.register(
     'registerActivity',
-    simpleTryRespond((_message: Message) => registerActivity(service)),
+    tryRespond((_message: Message) => registerActivity(service)),
   );
 
   service.register(

--- a/services/service.ts
+++ b/services/service.ts
@@ -397,7 +397,7 @@ function tryRespond<T extends Record<string, any>>(runner: (message: Message) =>
 }
 
 function runService(): void {
-  const service = new Service(serviceInfo.id, isLegacyBus ? createFakeActivityManager(30) : undefined, { idleTimer: 30 });
+  const service = new Service(serviceInfo.id, createFakeActivityManager(30));
   const serviceRemote = new ServiceRemote();
 
   // legacy webOS (pre-ACG) used two luna buses: private and public.

--- a/services/service.ts
+++ b/services/service.ts
@@ -18,8 +18,10 @@ import rootAppInfo from '../appinfo.json';
 import serviceInfo from './services.json';
 import { makeError, makeSuccess } from './protocol';
 import ServiceRemote from './webos-service-remote';
+import { createFakeActivityManager } from './fake-activity-manager';
 
-const kHomebrewChannelPackageId = rootAppInfo.id;
+const homebrewChannelPackageId = rootAppInfo.id;
+const autostartActivityName = `${homebrewChannelPackageId}.autostart`;
 const startDevmode = '/media/cryptofs/apps/usr/palm/services/com.palmdts.devmode.service/start-devmode.sh';
 const homebrewBaseDir = ((): string | null => {
   try {
@@ -29,6 +31,7 @@ const homebrewBaseDir = ((): string | null => {
     return null;
   }
 })();
+const isLegacyBus = fs.existsSync('/var/run/ls2/ls-hubd.private.pid');
 
 const nodeVersion = (() => {
   try {
@@ -80,7 +83,7 @@ function asyncCall<T extends Record<string, any>>(srv: Service, uri: string, arg
 function createToast(message: string, service: Service, extras: Record<string, any> = {}): Promise<Record<string, any>> {
   console.info(`[toast] ${message}`);
   return asyncCall(service, 'luna://com.webos.notification/createToast', {
-    sourceId: kHomebrewChannelPackageId,
+    sourceId: homebrewChannelPackageId,
     message,
     ...extras,
   });
@@ -321,8 +324,8 @@ async function removePackage(packageId: string, service: Service): Promise<void>
  */
 async function registerActivity(service: Service): Promise<void> {
   const activity = {
-    name: 'org.webosbrew.hbchannel.service.autostart',
-    description: 'Start HBChannel service on boot.',
+    name: autostartActivityName,
+    description: 'Start Homebrew Channel service on boot',
     type: {
       foreground: true,
       persist: true,
@@ -341,9 +344,6 @@ async function registerActivity(service: Service): Promise<void> {
     },
     callback: {
       method: 'luna://org.webosbrew.hbchannel.service/autostart',
-      params: {
-        reason: 'activity',
-      },
     },
   };
 
@@ -353,11 +353,11 @@ async function registerActivity(service: Service): Promise<void> {
     replace: true,
   };
 
-  return new Promise((resolve) => {
-    service.activityManager.create(spec, () => {
-      resolve();
-    });
-  });
+  await asyncCall(service, 'luna://com.palm.activitymanager/create', spec);
+}
+
+async function pauseActivity(service: Service, activityName: string = autostartActivityName) {
+  await asyncCall(service, 'luna://com.palm.activitymanager/pause', { activityName });
 }
 
 function simpleTryRespond(runner: (message: Message) => Promise<void>) {
@@ -396,8 +396,17 @@ function tryRespond<T extends Record<string, any>>(runner: (message: Message) =>
 }
 
 function runService(): void {
-  const service = new Service(serviceInfo.id, undefined, { idleTimer: 30 });
+  const service = new Service(serviceInfo.id, isLegacyBus ? createFakeActivityManager(30) : undefined, { idleTimer: 30 });
   const serviceRemote = new ServiceRemote();
+
+  // legacy webOS (pre-ACG) used two luna buses: private and public.
+  // by default, public handle is used for outbound calls.
+  // AM inherits bus from requests and attempts to call trigger on public bus,
+  // which does not work for our case
+  if (runningAsRoot && service.privateHandle) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    service.sendingHandle = service.privateHandle;
+  }
 
   function getInstallerService(): Service {
     if (runningAsRoot) {
@@ -481,7 +490,7 @@ function runService(): void {
       // If re-elevation fails for some reason the service should still be
       // re-elevated on reboot on devices with persistent autostart hooks (since
       // we launch elevate-service in startup.sh script)
-      if (runningAsRoot && isRecord(pkginfo) && pkginfo['Package'] === kHomebrewChannelPackageId) {
+      if (runningAsRoot && isRecord(pkginfo) && pkginfo['Package'] === homebrewChannelPackageId) {
         message.respond({ statusText: 'Self-update…' });
         await createToast('Performing self-update...', service);
 
@@ -781,6 +790,18 @@ function runService(): void {
   service.register(
     'autostart',
     tryRespond(async (message: Message) => {
+      const calledByActivity = /^com\.(?:palm|webos)(?:\.service)?\.activitymanager$/.test(
+        (message.ls2Message as { senderServiceName: () => string }).senderServiceName(),
+      );
+
+      // legacy ActivityManager does not expire/satisfy activity after invoking the callback
+      // to prevent the service from restarting over and over, manually pause the activity
+      // it's done without await to avoid slowing down autostart
+      if (isLegacyBus && calledByActivity) {
+        pauseActivity(service).catch((payload) => {
+          console.warn('failed to pause autostart activity', payload);
+        });
+      }
       if (!runningAsRoot) {
         return { message: 'Not running as root.', returnValue: true };
       }
@@ -810,9 +831,13 @@ function runService(): void {
         stdio: ['ignore', 'ignore', 'ignore'],
       });
 
-      // Register activity if autostart was triggered in traditional way
-      if (message.payload['reason'] !== 'activity') {
-        await registerActivity(service);
+      // frontend calls /autostart on launch
+      if (!calledByActivity) {
+        try {
+          await registerActivity(service);
+        } catch (e) {
+          console.warn('failed to register activity', e);
+        }
       }
 
       return { returnValue: true };


### PR DESCRIPTION
some quirks to get autostart activity to work on pre-ACG webOS:

- use private bus handle for outbound calls if service is privileged: activity inherits bus type and tries to call private-only trigger
- pause activity on `/autostart` to prevent continuous restart loop
- implement fake AM bindings to avoid adoption of autostart activity
- deprecate `previewMetadata` in app manifest
