### PR TITLE
Update engines field to node 22 or below 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "os": [
         "!win32"
     ],
+    "engines": {
+        "node": "<=22"
+    },
     "scripts": {
         "build": "enyo pack",
         "build-service": "webpack",


### PR DESCRIPTION
Took me a while to figure out that it doesn't work on node 24, so it might help somebody in the future