### PR TITLE
Replace the automatic failsafe trigger with an opt-in USB rescue marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Replace the automatic failsafe trigger with an opt-in USB rescue marker (@rbcetin; #240)
+
 ## [0.7.2] - 2024-11-16
 ### Fixed
 - Fix Luna calls when service not elevated (@mariotaku; #200)

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Features
     * SSH - public key authenticated (with default `alpine` password until
       authorized keys are provisioned)
     * Telnet - unauthenticated, use sparingly
-* (root) Failsafe mode
-    * In case a device crashes on boot only an emergency shell will be exposed
-      via telnet. In order to disable it fix the original crash cause and remove
-      `/var/luna/preferences/webosbrew_failsafe` flag file.
+* (root) Rescue mode
+    * Put an empty file named `webosbrew_rescue` in the root of any USB drive and
+      reboot. Root-related system customizations are skipped and only an emergency
+      shell is exposed via telnet. Remove the drive and reboot to go back to normal.
 
 Installation
 ------------

--- a/services/startup.sh
+++ b/services/startup.sh
@@ -25,10 +25,23 @@ touch "${once}"
 # Use default directory if SERVICE_DIR is not provided.
 SERVICE_DIR="${SERVICE_DIR-/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service}"
 
-if [[ -e /var/luna/preferences/webosbrew_failsafe ]]; then
-    # In case a reboot occured during last startup - open an emergency telnet
-    # server and nag user to actually fix this. (since further reboots could
-    # lead to devmode removal, etc...)
+# Rescue mode: an empty file named webosbrew_rescue in the root of any USB
+# drive. Partition letters move with what is plugged in, so walk the glob.
+rescue=
+for marker in /tmp/usb/*/*/webosbrew_rescue*; do
+    if [[ -e "${marker}" ]]; then
+        rescue=1
+        break
+    fi
+done
+
+if [[ -n "${rescue}" ]]; then
+    "${SERVICE_DIR}/bin/telnetd" -l /bin/sh
+    sleep 1
+
+    luna-send -a webosbrew -f -n 1 luna://com.webos.notification/createToast '{"sourceId":"webosbrew","message": "<b>Rescue mode!</b><br/>Telnet is open. Fix any causes, remove the USB drive and reboot."}'
+elif [[ -e /var/luna/preferences/webosbrew_failsafe ]]; then
+    # Open an emergency telnet server and nag user to actually fix this.
 
     "${SERVICE_DIR}/bin/telnetd" -l /bin/sh
     sleep 1
@@ -39,10 +52,6 @@ if [[ -e /var/luna/preferences/webosbrew_failsafe ]]; then
     sync -f /var/luna/preferences
     luna-send -a com.webos.service.secondscreen.gateway -f -n 1 luna://com.webos.notification/createAlert '{"sourceId":"webosbrew","message":"<b>Homebrew Channel</b> - Failsafe mode<br />A crash has occured during previous startup - root-related system customizations have been temporarily disabled.<br /><br /> System should go back to normal after a reboot.<br />Would you like to reboot now?","buttons":[{"label":"Reboot now","onclick":"luna://com.webos.service.sleep/shutdown/machineReboot","params":{"reason":"remoteKey"}},{"label":"Reboot later"}]}'
 else
-    # Set a failsafe flag and sync filesystem to make sure it actually gets
-    # tripped...
-    touch /var/luna/preferences/webosbrew_failsafe
-    sync -f /var/luna/preferences/webosbrew_failsafe
     sleep 2
 
     # Close fds to avoid leaking Luna socket
@@ -134,9 +143,4 @@ else
     # Run user startup hooks
     mkdir -p /var/lib/webosbrew/init.d
     run-parts /var/lib/webosbrew/init.d 200>&-
-
-    # Reset failsafe flag after a while
-    sleep 10
-    rm -rf /var/luna/preferences/webosbrew_failsafe
-    sync -f /var/luna/preferences
 fi


### PR DESCRIPTION
Closes #88.

`startup.sh` writes `webosbrew_failsafe` early in boot and removes it ~10 s after `run-parts`. A reset inside that window costs the next boot every root customization. On an OLED65C9PLA (webOS 4.5) the flag lands at **boot+26 s** while `tvpowerd` reaches `Active` at **+13 s** — so the window opens well after the TV is already on, which is exactly where someone cutting power again would land.

Nothing sets the flag automatically any more. The branch that honours it is untouched — including its flag clear, because the settings panel's "Failsafe mode" toggle is bound to that flag and is `disabled` unless root is active, so a branch that stopped clearing it would pin failsafe on with the control that set it greyed out.

The rescue lever for the no-shell case is an empty `webosbrew_rescue` file in the root of any USB drive.

### vs #224

@kitsuned's #224 set out to solve this and I'm building on it. Two differences:

- **A file, not a filesystem label** — @throwaway96's objection there (*"No way people are going to be able to figure out how to do that"*) seems right to me.
- **`/dev/disk/by-label` doesn't exist on webOS 4.x.** Those symlinks come from udev, and there is none here — no `/dev/disk` at all, `/proc/sys/kernel/hotplug` is an LG binary posting to their own device manager. With a drive plugged in, `blkid` reports its label and it's mounted at `/tmp/usb/sda/sda1`, but `ls /dev/disk/` is still `No such file or directory`. That check can never fire on these sets.

The glob walks `/tmp/usb/*/*/` rather than hardcoding `sda1`, and matches a suffix because Notepad appends `.txt` whether you ask it to or not.

### Testing

OLED65C9PLA / webOS 4.5 / HBC 0.7.3, five boots. Without a marker: dropbear and an `init.d` hook both up in ~27 s, no flag written. With one: telnet up, both skipped. Removing it returns to normal.

Two were mains cuts at the wall — one plain cold cycle, and one pulling power again 28 s into the boot, right where the flag used to sit. Both clean. The rescue boot also settles the timing question: `/tmp/usb` is filled by LG's device manager and the check runs at +26 s, but a drive present at power-on is mounted in time.

Caveat: verified on webOS 4.5 only. `README.md` updated; the webosbrew.org docs need a pass too.
